### PR TITLE
Add control instance and documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.tfstate
+*.tfstate.backup
+*.out
+.terraform

--- a/README.md
+++ b/README.md
@@ -1,2 +1,99 @@
-# kubernetes-config-and-doc
-Testing kubernetes config and procedure documentation
+# Kubernetes Cluster
+
+## Install Kubernetes Cluster.
+I'm following the kubernets documentation to set up a basic cluster in AWS using [kops][0], being that I have this tools by hand and due to the time constraint. Having more time I would check for [kubeadm][1].
+
+- Documentation: [Kubernetes kops documentation][2]
+
+### Pre-requisites
+- AWS Cli installed and configured with admin credentials in the host you'll be running terraform.
+	+ MacOS:
+		* Install AWS CLI (asumming you already have homebrew configured):
+			$ brew install awscli
+		* Configure AWS Credentials
+			- Create IAM User with admin privileges.
+			- Generate a credential pair for the user.
+				+ Add the credentials into your home directory
+					* mkdir -p ~/.aws
+					* vim ~/.aws/credentials
+
+					```
+					[default]
+					aws_access_key_id =  ********************
+					aws_secret_access_key = ****************************************
+					```
+	+ Testing the AWS CLI
+	```
+	$ aws ec2 describe-instances --region eu-west-1 --output json > /dev/null
+	$ echo $?
+	0
+	```
+- Install terraform binary. As pre-requisite, I'll install [Terraform][4] in my laptop, currently using MacOS, but there are options for other operating systems.
+	+ Download [Terraform binary][5].
+	+ Extract the binary and deploy to a system path to be used.
+	```
+	$ unzip terraform_0.11.13_darwin_amd64.zip
+	Archive:  terraform_0.11.13_darwin_amd64.zip
+	  inflating: terraform
+	$ mkdir -p ~/bin                                                                       $ mv -v terraform ~/bin
+	terraform -> /Users/dbandin/bin/terraform
+	$ export PATH=$PATH:~/bin
+	$ echo $PATH
+	/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/Users/dbandin/bin
+	$ terraform --version
+	Terraform v0.11.13
+	$ echo "export PATH=$PATH:~/bin" >> ~/.zshrc
+	```
+
+
+### Creating a cluster
+The first section of the documentation points that requires [kubectl][3] for kops to work, I'll create and AWS instance with kubectl to avoid problems with connectivity.
+
+#### Create the control instance for kubectl
+Need first to create a VPC (Virtual Network) to hold the cluster and control instance. The control instance could be inside or outside the VPC, I'll make it inside, so, it's easier to replicate the provisioning and tools installation.
+
+Using the terraform template in this repository [kubernetes_vpc.tf](terraform_templates/kubernetes_vpc.tf) we can create a vpc with public access and an instance in it to deploy kubectl later.
+
+##### Steps to create control instance
+- step into the repository directory with the terraform template.
+```
+$ pwd
+~/repositories/kubernetes-config-and-doc/terraform_templates
+```
+- Run terraform plan to see the resources to be created.
+```
+$ terraform plan
+```
+- If everything looks good in the plan output, create the stack
+```
+$ terraform apply
+...
+Outputs:
+
+instance-id = i-00123456790abcdef
+instance-public-ip = 54.111.111.111
+key-id = KubeControlKey
+vpc-id = vpc-00123456790abcdef
+vpc-publicsubnet = 192.168.0.0/24
+vpc-publicsubnet-id = subnet-00123456790abcdef
+```
+- Test the connection to the instance
+```
+$ ssh -i ~/.ssh/DiegoTest.pem -l ec2-user 54.111.111.111
+```
+
+#### Install kubectl
+Following the [kubectl installation][3] on Linux will deploy it to an AWS instance.
+
+Once Logged in to the control instance created in the previous step, you can download and install kubectl.
+
+Sadly, it cannot be installed used the yum/rpm option because the signature google files are not working and doesn't seem to have any activity from the maintainers. [kubectl bug](https://github.com/kubernetes/kubernetes/issues/60134)
+
+kubectl and kops are added to the user_data of the control instance in the terraform template, it's not necessary to intervene manually.
+
+[0]: https://github.com/kubernetes/kops "Kops Repository"
+[1]: https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm/ "kubeadm Documentation"
+[2]: https://kubernetes.io/docs/setup/custom-cloud/kops/ "Kubernetes kops documentation"
+[3]: https://kubernetes.io/docs/tasks/tools/install-kubectl/ "kubectl installation"
+[4]: https://www.terraform.io/ "Terraform"
+[5]: https://releases.hashicorp.com/terraform/0.11.13/terraform_0.11.13_darwin_amd64.zip "Terraform Binary"

--- a/terraform_templates/kubernetes_vpc.tf
+++ b/terraform_templates/kubernetes_vpc.tf
@@ -1,0 +1,113 @@
+provider "aws" {
+  region = "eu-west-1"
+  shared_credentials_file = "${pathexpand("~/.aws/credentials")}"
+}
+resource "aws_vpc" "terraform-vpc" {
+  cidr_block = "192.168.0.0/16"
+  instance_tenancy = "default"
+  enable_dns_support = "true"
+  enable_dns_hostnames = "true"
+  enable_classiclink = "false"
+  tags {
+    Name = "Control VPC"
+  }
+}
+
+resource "aws_subnet" "public-1" {
+  vpc_id = "${aws_vpc.terraform-vpc.id}"
+  cidr_block = "192.168.0.0/24"
+  map_public_ip_on_launch = "true"
+  availability_zone = "eu-west-1b"
+  tags {
+    Name = "public"
+  }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = "${aws_vpc.terraform-vpc.id}"
+  tags {
+    Name = "internet-gateway"
+  }
+}
+
+resource "aws_route_table" "rt1" {
+  vpc_id = "${aws_vpc.terraform-vpc.id}"
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.gw.id}"
+  }
+  tags {
+    Name = "Default"
+  }
+}
+
+resource "aws_route_table_association" "association-subnet" {
+  subnet_id = "${aws_subnet.public-1.id}"
+  route_table_id = "${aws_route_table.rt1.id}"
+}
+
+resource "aws_instance" "terraform_linux" {
+  ami = "ami-07683a44e80cd32c5"
+  instance_type = "t2.micro"
+  vpc_security_group_ids = ["${aws_security_group.sshsg.id}"]
+  subnet_id = "${aws_subnet.public-1.id}"
+  key_name = "${aws_key_pair.kube_control_key.key_name}"
+  lifecycle {
+    create_before_destroy = true
+  }
+  tags {
+    Name = "control-vpc"
+  }
+  user_data = "${file("scripts/control_instance_user_data.sh")}"
+}
+
+resource "aws_key_pair" "kube_control_key" {
+  key_name = "KubeControlKey"
+  public_key = "${file("~/.ssh/DiegoTest.pub")}"
+}
+
+resource "aws_security_group" "sshsg" {
+  name = "security_group_for_kub_control_ssh"
+  vpc_id = "${aws_vpc.terraform-vpc.id}"
+  ingress {
+    from_port = 22
+    to_port = 22
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+output "vpc-id" {
+  value = "${aws_vpc.terraform-vpc.id}"
+}
+
+output "vpc-publicsubnet" {
+  value = "${aws_subnet.public-1.cidr_block}"
+}
+
+output "vpc-publicsubnet-id" {
+  value = "${aws_subnet.public-1.id}"
+}
+
+output "instance-id" {
+  value = "${aws_instance.terraform_linux.id}"
+}
+
+output "instance-public-ip" {
+  value = "${aws_instance.terraform_linux.public_ip}"
+}
+
+output "key-id" {
+  value = "${aws_key_pair.kube_control_key.key_name}"
+}

--- a/terraform_templates/scripts/control_instance_user_data.sh
+++ b/terraform_templates/scripts/control_instance_user_data.sh
@@ -1,0 +1,7 @@
+  #!/bin/bash
+  curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+  chmod +x kubectl
+  mv kubectl /usr/local/bin
+  wget https://github.com/kubernetes/kops/releases/download/1.10.0/kops-linux-amd64
+  chmod +x kops-linux-amd64
+  mv kops-linux-amd64 /usr/local/bin/kops


### PR DESCRIPTION
Add documentation and template to create control
instance and documentation.
This commit contains:
- .gitignore to avoid adding terraform temporary files.
- README.md with documentation.
- kubernetes_vpc.tf file with a vpc and a ec2 instance with
internet access and the tools kubectl and kops